### PR TITLE
enable buildjet runners for flutter sdk

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-2vcpu-ubuntu-2204
     permissions:
       id-token: write # Required for authentication using GitHub-signed OIDC token
     steps:


### PR DESCRIPTION
This PR switches to 2vcpu runners from buildjet.